### PR TITLE
Syntactic consistency changes

### DIFF
--- a/jquery.boilerplate.coffee
+++ b/jquery.boilerplate.coffee
@@ -21,7 +21,7 @@
 
   # The actual plugin constructor
   class Plugin
-    constructor: (@elements, options) ->
+    constructor: (@element, options) ->
       # jQuery has an extend method which merges the contents of two or
       # more objects, storing the result in the first object. The first object
       # is generally empty as we don't want to alter the default options for


### PR DESCRIPTION
I changed the CoffeeScript version a little to make the syntax a little more consistent:
- don't use a whitespace when defining function arguments
- use String interpolation when necessary, and avoid it when possible
- rename `@elements` instance variable to `@element` to match the original JS version

Might be worth an update.
