### PR TITLE
Add ability to call public prototype functions from plugin

### DIFF
--- a/jquery.boilerplate.coffee
+++ b/jquery.boilerplate.coffee
@@ -38,10 +38,19 @@
       # You already have access to the DOM element and the options via the instance,
       # e.g., this.element and this.options
 
-  # A really lightweight plugin wrapper around the constructor,
-  # preventing against multiple instantiations
-  $.fn[pluginName] = (options) ->
-    this.each ->
-      if !$.data(this, "plugin_#{pluginName}")
-        $.data(this, "plugin_#{pluginName}", new Plugin(this, options))
+  # A really lightweight plugin wrapper around the constructor, 
+  # preventing against multiple instantiations and allowing any
+  # public function (ie. a function whose name doesn't start
+  # with an underscore) to be called via the jQuery plugin,
+  # e.g. $(element).defaultPluginName('functionName', arg1, arg2)
+  $.fn[pluginName] = (options, args...) ->
+    if options is undefined or typeof options is 'object'
+      this.each ->
+        if !$.data(this, "plugin_#{pluginName}")
+          $.data(this, "plugin_#{pluginName}", new Plugin(this, options))
+    else if typeof options is 'string' and options[0] isnt '_' and options isnt 'init'
+      this.each ->
+        instance = $.data(this, "plugin_#{pluginName}")
+        if instance instanceof Plugin and typeof instance[options] is 'function'
+          instance[options].apply( instance, args)
 )(jQuery, window, document)

--- a/jquery.boilerplate.js
+++ b/jquery.boilerplate.js
@@ -48,13 +48,26 @@
     };
 
     // A really lightweight plugin wrapper around the constructor, 
-    // preventing against multiple instantiations
+    // preventing against multiple instantiations and allowing any
+    // public function (ie. a function whose name doesn't start
+    // with an underscore) to be called via the jQuery plugin,
+    // e.g. $(element).defaultPluginName('functionName', arg1, arg2)
     $.fn[pluginName] = function ( options ) {
-        return this.each(function () {
-            if (!$.data(this, 'plugin_' + pluginName)) {
-                $.data(this, 'plugin_' + pluginName, new Plugin( this, options ));
-            }
-        });
+        var args = arguments;
+        if (options === undefined || typeof options === 'object') {
+            return this.each(function () {
+                if (!$.data(this, 'plugin_' + pluginName)) {
+                    $.data(this, 'plugin_' + pluginName, new Plugin( this, options ));
+                }
+            });
+        } else if (typeof options === 'string' && options[0] !== '_' && options !== 'init') {
+            return this.each(function () {
+                var instance = $.data(this, 'plugin_' + pluginName);
+                if (instance instanceof Plugin && typeof instance[options] === 'function') {
+                    instance[options].apply( instance, Array.prototype.slice.call( args, 1 ) );
+                }
+            });
+        }
     }
 
 })(jQuery, window, document);

--- a/jquery.boilerplate.min.js
+++ b/jquery.boilerplate.min.js
@@ -20,11 +20,21 @@
     };
 
     $.fn[pluginName] = function ( options ) {
-        return this.each(function () {
-            if (!$.data(this, 'plugin_' + pluginName)) {
-                $.data(this, 'plugin_' + pluginName, new Plugin( this, options ));
-            }
-        });
+        var args = arguments;
+        if (options === undefined || typeof options === 'object') {
+            return this.each(function () {
+                if (!$.data(this, 'plugin_' + pluginName)) {
+                    $.data(this, 'plugin_' + pluginName, new Plugin( this, options ));
+                }
+            });
+        } else if (typeof options === 'string' && options[0] !== '_' && options !== 'init') {
+            return this.each(function () {
+                var instance = $.data(this, 'plugin_' + pluginName);
+                if (instance instanceof Plugin && typeof instance[options] === 'function') {
+                    instance[options].apply( instance, Array.prototype.slice.call( args, 1 ) );
+                }
+            });
+        }
     }
 
 })(jQuery, window, document);


### PR DESCRIPTION
Hey guys,

I really like your plugin boilerplate. I'd actually been thinking of making something similar for a while. Am I right in assuming that the code is partly inspired by some of my work from my blog post "Creating Highly Configurable jQuery Plugins" since I saw Addy Osmani feature it in his Smashing Magazine article, "Essential jQuery Plugin Patterns"? :)

I've added some code to the plugin wrapper that exposes any "public" function (ie. not beginning with an underscore) to the plugin,
e.g. `$(element).defaultPluginName('functionName', arg1, arg2)`

I can see that the idea of this project is to keep the amount of boilerplate code to a minimum, but this is one feature that I think would benefit most plugin authors and is something that's tricky to implement manually in every project, making it perfect for a boilerplate.

Let me know, assuming you want to include this functionality, if there's any changes to the code or documentation that you'd like me to make.

Cheers,
Mark Dalgleish
