### PR TITLE
Allow access to public prototype methods

### DIFF
--- a/jquery.boilerplate.coffee
+++ b/jquery.boilerplate.coffee
@@ -49,6 +49,11 @@
     else if typeof options is 'string' and options[0] isnt '_' and options isnt 'init'
       this.each ->
         instance = $.data(this, "plugin_#{pluginName}")
+        
         if instance instanceof Plugin and typeof instance[options] is 'function'
           instance[options].apply( instance, args)
+        
+        # Allow instances to be destroyed via the 'destroy' method
+        if options is 'destroy'
+          $.data(this, "plugin_#{pluginName}", null)
 )(jQuery, window)

--- a/jquery.boilerplate.js
+++ b/jquery.boilerplate.js
@@ -63,8 +63,14 @@
         } else if (typeof options === 'string' && options[0] !== '_' && options !== 'init') {
             return this.each(function () {
                 var instance = $.data(this, 'plugin_' + pluginName);
+
                 if (instance instanceof Plugin && typeof instance[options] === 'function') {
                     instance[options].apply( instance, Array.prototype.slice.call( args, 1 ) );
+                }
+								
+								// Allow instances to be destroyed via the 'destroy' method
+                if (options === 'destroy') {
+                  $.data(this, 'plugin_' + pluginName, null);
                 }
             });
         }

--- a/jquery.boilerplate.min.js
+++ b/jquery.boilerplate.min.js
@@ -31,8 +31,13 @@
         } else if (typeof options === 'string' && options[0] !== '_' && options !== 'init') {
             return this.each(function () {
                 var instance = $.data(this, 'plugin_' + pluginName);
+
                 if (instance instanceof Plugin && typeof instance[options] === 'function') {
                     instance[options].apply( instance, Array.prototype.slice.call( args, 1 ) );
+                }
+
+								if (options === 'destroy') {
+                  $.data(this, 'plugin_' + pluginName, null);
                 }
             });
         }


### PR DESCRIPTION
I saw that you wanted to add this functionality based on @dbashyal's issue, so I figured I'd get my fork up to date and submit a pull request.

Another really useful feature I've since added (which I think is a vital part of this update) is the ability to remove instances of the plugin via the 'destroy' method, e.g. I use $.stellar('destroy') in my Stellar.js plugin. It calls my internal 'destroy' method, so I can do some necessary clean-up, then removes the instance from the data.

Let me know if there are any changes you'd like me to make :)
