### PR TITLE
Fixing how the Plugin constructor got the element

### DIFF
--- a/jquery.boilerplate.js
+++ b/jquery.boilerplate.js
@@ -27,7 +27,7 @@
 
     // The actual plugin constructor
     function Plugin( element, options ) {
-        this.element = element;
+        this.element = $(element);
 
         // jQuery has an extend method which merges the contents of two or
         // more objects, storing the result in the first object. The first object


### PR DESCRIPTION
After trying the boilerplate I could'nt make it do a simple  "this.element.append('<p>etc..</p>');"
I found out that if doing it like the hub.me it would work, so I changed and commited it.

Hope I'm not talking bullshit here, but this worked for me.
