### PR TITLE
Remove `new` constructor usage and need for references to `this`

### DIFF
--- a/jquery.boilerplate.js
+++ b/jquery.boilerplate.js
@@ -1,19 +1,19 @@
 /*
- *  Project: 
- *  Description: 
- *  Author: 
- *  License: 
+ *  Project:
+ *  Description:
+ *  Author:
+ *  License:
  */
 
 // the semi-colon before function invocation is a safety net against concatenated
 // scripts and/or other plugins which may not be closed properly.
 ;(function ( $, window, undefined ) {
-    
+
     // undefined is used here as the undefined global variable in ECMAScript 3 is
     // mutable (ie. it can be changed by someone else). undefined isn't really being
     // passed in so we can ensure the value of it is truly undefined. In ES5, undefined
     // can no longer be modified.
-    
+
     // window is passed through as local variable rather than global
     // as this (slightly) quickens the resolution process and can be more efficiently
     // minified (especially when both are regularly referenced in your plugin).
@@ -25,26 +25,28 @@
             propertyName: "value"
         };
 
-    // The actual plugin constructor
-    function Plugin( element, options ) {
-        this.element = element;
+    function plugin(element, options){
 
-        // jQuery has an extend method which merges the contents of two or
-        // more objects, storing the result in the first object. The first object
-        // is generally empty as we don't want to alter the default options for
-        // future instances of the plugin
-        this.options = $.extend( {}, defaults, options) ;
-        
-        this._defaults = defaults;
-        this._name = pluginName;
-        
-        this.init();
-    }
+      // jQuery has an extend method that merges the
+      // contents of two or more objects, storing the
+      // result in the first object. The first object
+      // is generally empty because we don't want to alter
+      // the default options for future instances of the plugin
+      options = $.extend( {}, defaults, options) ;
 
-    Plugin.prototype.init = function () {
+      var name = pluginName;
+
+      var init = function () {
         // Place initialization logic here
-        // You already have access to the DOM element and the options via the instance,
-        // e.g., this.element and this.options
+        // You already have access to the DOM element and the options,
+        // e.g., `element` and `options`
+      };
+
+      // Public interface
+      return {
+        init: init
+        options: options
+      };
     };
 
     // A really lightweight plugin wrapper around the constructor,
@@ -52,7 +54,7 @@
     $.fn[pluginName] = function ( options ) {
         return this.each(function () {
             if (!$.data(this, 'plugin_' + pluginName)) {
-                $.data(this, 'plugin_' + pluginName, new Plugin( this, options ));
+                $.data(this, 'plugin_' + pluginName, plugin(this, options).init());
             }
         });
     };


### PR DESCRIPTION
I reworked the plugin initialization a bit to work more like how I've been writing objects in javascript lately. The main benefits are that it removes the need to reference `this` altogether and allows you to explicitly set the public interface rather than relying on prefixing properties with `_`.

Not sure if you'd want this pulled in, but figured I'd create a pull request in case you did. Thanks!
