### PR TITLE
Remove closure wrapper from CoffeeScript version

### DIFF
--- a/jquery.boilerplate.coffee
+++ b/jquery.boilerplate.coffee
@@ -3,47 +3,49 @@
 #  Author:
 #  License:
 
-# Note that when compiling with coffeescript, the plugin is wrapped in another
-# anonymous function. We do not need to pass in undefined as well, since
-# coffeescript uses (void 0) instead.
-(($, window, document) ->
+# Note that when compiling with CoffeeScript, the plugin is wrapped in an
+# anonymous function automatically.
 
-  # window and document are passed through as local variable rather than global
-  # as this (slightly) quickens the resolution process and can be more efficiently
-  # minified (especially when both are regularly referenced in your plugin).
+$ = jQuery
 
-  # Create the defaults once
-  pluginName = "defaultPluginName"
-  defaults =
-    property: "value"
+# window and document are redefined here as local variables as this (slightly)
+# quickens the resolution process and can be more efficiently minified
+# (especially when both are regularly referenced in your plugin).
+# We do not need to worry about undefined, as CoffeeScript automatically
+# converts this to (void 0).
+window = window
+document = document
 
-  # The actual plugin constructor
-  class Plugin
-    constructor: (@element, options) ->
-      # jQuery has an extend method which merges the contents of two or
-      # more objects, storing the result in the first object. The first object
-      # is generally empty as we don't want to alter the default options for
-      # future instances of the plugin
-      @options = $.extend {}, defaults, options
+# Create the defaults once
+pluginName = "defaultPluginName"
+defaults =
+  property: "value"
 
-      @_defaults = defaults
-      @_name = pluginName
+# The actual plugin constructor
+class Plugin
+  constructor: (@element, options) ->
+    # jQuery has an extend method which merges the contents of two or
+    # more objects, storing the result in the first object. The first object
+    # is generally empty as we don't want to alter the default options for
+    # future instances of the plugin
+    @options = $.extend {}, defaults, options
 
-      @init()
+    @_defaults = defaults
+    @_name = pluginName
 
-    init: ->
-      # Place initialization logic here
-      # You already have access to the DOM element and the options via the instance,
-      # e.g., @element and @options
+    @init()
 
-    yourOtherFunction: ->
-      # some logic
+  init: ->
+    # Place initialization logic here
+    # You already have access to the DOM element and the options via the instance,
+    # e.g., @element and @options
 
-  # A really lightweight plugin wrapper around the constructor,
-  # preventing against multiple instantiations
-  $.fn[pluginName] = (options) ->
-    @each ->
-      if !$.data(this, "plugin_#{pluginName}")
-        $.data(@, "plugin_#{pluginName}", new Plugin(@, options))
+  yourOtherFunction: ->
+    # some logic
 
-)( jQuery, window, document )
+# A really lightweight plugin wrapper around the constructor,
+# preventing against multiple instantiations
+$.fn[pluginName] = (options) ->
+  @each ->
+    if !$.data(this, "plugin_#{pluginName}")
+      $.data(@, "plugin_#{pluginName}", new Plugin(@, options))


### PR DESCRIPTION
The first comment in the CoffeeScript version says:

```
Note that when compiling with coffeescript, the plugin is wrapped in another anonymous function.
```

So why add another one then?

To localise `window` and `document` and `$`, you can just declare them at the top. This gets exactly the same job done – localising the variables for performance/minification – in a way that is cleaner and more straightforward.
