### PR TITLE
Public methods

### DIFF
--- a/jquery.boilerplate.js
+++ b/jquery.boilerplate.js
@@ -62,7 +62,7 @@
         return this.each(function () {
             var _plugin = "plugin_" + pluginName,
                 data = $.data(this, _plugin),
-                method = data[options];
+                method = data ? data[options] : '';
 
             // Instance the plugin
             if (!data) {


### PR DESCRIPTION
Rewriting plugin wrapper adding the possibility of using public methods
like a parameter.

<code>$(el).plugin('publicMethod' [, arg1, arg2, ...]);</code>
