### PR TITLE
Add repository to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
 	"title": "jQuery Boilerplate",
 	"description": "A jump-start for jQuery plugins development.",
 	"author": "Zeno Rocha",
+  "repository": {
+    "type" : "git",
+    "url" : "http://github.com/jquery-boilerplate/boilerplate.git"
+  },
 	"homepage": "https://github.com/jquery-boilerplate/boilerplate/",
 	"version": "3.3.1",
 	"devDependencies": {


### PR DESCRIPTION
Using the latest jquery-boilerplate, when I do an "npm install", I get the following warning:

```
npm WARN package.json boilerplate@0.1.0 No repository field.
```

This pull request adds a repository field to package.json, fixing that warning. 

The repository field is specified the canonical way (as per https://npmjs.org/doc/json.html) for a git repo.
