### PR TITLE
Remove outdated JSHint options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,8 +8,6 @@
 	"noarg": true,
 	"onevar": true,
 	"quotmark": "double",
-	"smarttabs": true,
-	"trailing": true,
 	"unused": true,
 	"node": true
 }


### PR DESCRIPTION
Since JSHint v2.5 the `trailing` and `smarttabs` JSHint options are removed.

See https://github.com/jshint/jshint/releases/tag/2.5.0
