### PR TITLE
`.editorconfig`: indentation for `package.json`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,9 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[package.json]
+; The indent size used in the `package.json` file cannot be changed
+; https://github.com/npm/npm/pull/3180#issuecomment-16336516
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
The indent size used in the `package.json` file cannot be changed, it will always be 2 spaces. See https://github.com/npm/npm/pull/3180 about this.
