### PR TITLE
Make some minor changes into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "url": "https://github.com/heldr"
     }
   ],
-  "licenses": "MIT",
+  "license": "MIT",
   "private": true,
   "devDependencies": {
     "grunt": "~0.4.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     }
   ],
   "license": "MIT",
-  "private": true,
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-cli": "~0.1.13",


### PR DESCRIPTION
Hello! I made some minor changes into package.json.

1. `licenses` field is [deprecated](https://github.com/npm/npm/issues/4473). Only `license` is specified in the package.json [documentation](https://docs.npmjs.com/files/package.json#license).
2. Since the jQuery plugin registry is dead, i don't see any reason to set `private` to `true`. As they said: "We recommend moving to npm, using "jquery-plugin" as the keyword in your package.json."