### PR TITLE
more grunt 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,18 +62,58 @@ module.exports = function(grunt) {
 		watch: {
 		    files: ['src/*'],
 		    tasks: ['default']
+		},
+		// update bower.json with data from package.json
+		update_json: {
+			options: {
+				src: "package.json",
+				indent: " "
+			},
+			bower: {
+				dest: 'bower.json',
+				fields: { //to: "from",
+					name: "name",
+					version: "version",
+					description: "description",
+					repository: "repository",
+					keywords: "keywords",
+					homepage: "homepage",
+					main: "main",
+					license: "license",
+					authors: [{
+						name: "/author/name",
+						email: "/author/email",
+						homepage: "/author/url"
+					}]
+				}
+			}
+		},
+		bump: {
+			options: {
+				files: ['package.json', 'bower.json'],
+				updateConfigs: ['pkg'],
+				commit: true,
+				commitMessage: 'Release v%VERSION%',
+				commitFiles: ['-a'],
+				createTag: true,
+				tagName: 'v%VERSION%',
+				tagMessage: 'Version %VERSION%',
+				push: true,
+				pushTo: 'origin',
+				gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+				globalReplace: false,
+				prereleaseName: false,
+				regExp: false
+			}
 		}
 
 	});
 
-	grunt.loadNpmTasks("grunt-contrib-concat");
-	grunt.loadNpmTasks("grunt-contrib-jshint");
-	grunt.loadNpmTasks("grunt-contrib-uglify");
-	grunt.loadNpmTasks("grunt-contrib-coffee");
-	grunt.loadNpmTasks("grunt-contrib-watch");
+	require('load-grunt-tasks')(grunt); //DRY replacement for loadNpmTasks()
 
-	grunt.registerTask("build", ["concat", "uglify"]);
+	grunt.registerTask("build", ["concat", "uglify", "update_json"]);
 	grunt.registerTask("default", ["jshint", "build"]);
+	grunt.registerTask("release", ["bump"]);
 	grunt.registerTask("travis", ["default"]);
 
 };

--- a/package.json
+++ b/package.json
@@ -41,12 +41,15 @@
   "license": "MIT",
   "devDependencies": {
     "grunt": "~0.4.5",
+    "grunt-bump": "^0.3.0",
     "grunt-cli": "~0.1.13",
     "grunt-contrib-coffee": "^0.12.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-uglify": "^0.8.0",
-    "grunt-contrib-watch": "^0.6.1"
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-update-json": "^0.2.1",
+    "load-grunt-tasks": "^3.1.0"
   },
   "scripts": {
     "test": "grunt travis --verbose"


### PR DESCRIPTION
add grunt configurations that keep version numbers in packages.json, bower.json, and release tags all in sync