### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
 	"name": "jquery-boilerplate",
-	"version": "3.5.0",
 	"homepage": "http://jqueryboilerplate.com",
 	"authors": [
 		"Zeno Rocha <hi@zenorocha.com>"


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property