### PR TITLE
Beautify and ESLint supports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,242 @@
+{
+    "env": {
+        "browser": true,
+        "jquery": true,
+        "qunit": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "accessor-pairs": "error",
+        "array-bracket-spacing": [
+            "error",
+            "always"
+        ],
+        "array-callback-return": "error",
+        "arrow-body-style": "error",
+        "arrow-parens": "error",
+        "arrow-spacing": "error",
+        "block-scoped-var": "error",
+        "block-spacing": "error",
+        "brace-style": "error",
+        "callback-return": "error",
+        "camelcase": "error",
+        "comma-dangle": "error",
+        "comma-spacing": [
+            "error",
+            {
+                "after": true,
+                "before": false
+            }
+        ],
+        "comma-style": [
+            "error",
+            "last"
+        ],
+        "complexity": "error",
+        "computed-property-spacing": [
+            "error",
+            "always"
+        ],
+        "consistent-return": "error",
+        "consistent-this": "error",
+        "curly": "error",
+        "default-case": "error",
+        "dot-location": "error",
+        "dot-notation": "error",
+        "eol-last": "error",
+        "eqeqeq": "error",
+        "func-names": [
+            "error",
+            "never"
+        ],
+        "func-style": [
+            "error",
+            "declaration"
+        ],
+        "generator-star-spacing": "error",
+        "global-require": "error",
+        "guard-for-in": "error",
+        "handle-callback-err": "error",
+        "id-blacklist": "error",
+        "id-length": "off",
+        "id-match": "error",
+        "indent": ["error", "tab"],
+        "init-declarations": "error",
+        "jsx-quotes": "error",
+        "key-spacing": "error",
+        "keyword-spacing": "error",
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "lines-around-comment": "error",
+        "max-depth": "error",
+        "max-lines": "error",
+        "max-nested-callbacks": "error",
+        "max-params": "off",
+        "max-statements": [
+            "error",
+            10,
+            {
+                "ignoreTopLevelFunctions": true
+            }
+        ],
+        "max-statements-per-line": "error",
+        "multiline-ternary": "off",
+        "new-cap": "error",
+        "new-parens": "error",
+        "newline-after-var": [
+            "error",
+            "always"
+        ],
+        "newline-before-return": "error",
+        "newline-per-chained-call": "error",
+        "no-alert": "error",
+        "no-array-constructor": "error",
+        "no-bitwise": "error",
+        "no-caller": "error",
+        "no-catch-shadow": "error",
+        "no-confusing-arrow": "error",
+        "no-continue": "error",
+        "no-div-regex": "error",
+        "no-duplicate-imports": "error",
+        "no-else-return": "error",
+        "no-empty-function": "error",
+        "no-eq-null": "error",
+        "no-eval": "error",
+        "no-extend-native": "error",
+        "no-extra-bind": "error",
+        "no-extra-label": "error",
+        "no-extra-parens": "error",
+        "no-extra-semi": "off",
+        "no-floating-decimal": "error",
+        "no-implicit-coercion": "error",
+        "no-implicit-globals": "error",
+        "no-implied-eval": "error",
+        "no-inline-comments": "error",
+        "no-invalid-this": "off",
+        "no-iterator": "error",
+        "no-label-var": "error",
+        "no-labels": "error",
+        "no-lone-blocks": "error",
+        "no-lonely-if": "error",
+        "no-loop-func": "error",
+        "no-magic-numbers": "error",
+        "no-mixed-operators": "error",
+        "no-mixed-requires": "error",
+        "no-multi-spaces": "error",
+        "no-multi-str": "error",
+        "no-multiple-empty-lines": "error",
+        "no-negated-condition": "error",
+        "no-nested-ternary": "error",
+        "no-new": "error",
+        "no-new-func": "error",
+        "no-new-object": "error",
+        "no-new-require": "error",
+        "no-new-wrappers": "error",
+        "no-octal-escape": "error",
+        "no-param-reassign": [
+            "error",
+            {
+                "props": false
+            }
+        ],
+        "no-path-concat": "error",
+        "no-plusplus": "error",
+        "no-process-env": "error",
+        "no-process-exit": "error",
+        "no-proto": "error",
+        "no-prototype-builtins": "error",
+        "no-restricted-globals": "error",
+        "no-restricted-imports": "error",
+        "no-restricted-modules": "error",
+        "no-restricted-syntax": "error",
+        "no-return-assign": "error",
+        "no-script-url": "error",
+        "no-self-compare": "error",
+        "no-sequences": "error",
+        "no-shadow": "error",
+        "no-shadow-restricted-names": "off",
+        "no-spaced-func": "error",
+        "no-sync": "error",
+        "no-tabs": "off",
+        "no-ternary": "error",
+        "no-throw-literal": "error",
+        "no-trailing-spaces": "error",
+        "no-undef-init": "error",
+        "no-undefined": "off",
+        "no-unmodified-loop-condition": "error",
+        "no-unneeded-ternary": "error",
+        "no-unused-expressions": "error",
+        "no-use-before-define": "error",
+        "no-useless-call": "error",
+        "no-useless-computed-key": "error",
+        "no-useless-concat": "error",
+        "no-useless-constructor": "error",
+        "no-useless-escape": "error",
+        "no-useless-rename": "error",
+        "no-var": "off",
+        "no-void": "error",
+        "no-warning-comments": "error",
+        "no-whitespace-before-property": "error",
+        "no-with": "error",
+        "no-unused-vars": [
+            "error", {
+                "argsIgnorePattern": "undefined"
+            }
+        ],
+        "object-curly-newline": "off",
+        "object-curly-spacing": "error",
+        "object-property-newline": "error",
+        "object-shorthand": "off",
+        "one-var": "error",
+        "one-var-declaration-per-line": "error",
+        "operator-assignment": "error",
+        "operator-linebreak": "error",
+        "padded-blocks": "off",
+        "prefer-arrow-callback": "off",
+        "prefer-const": "error",
+        "prefer-reflect": "error",
+        "prefer-rest-params": "error",
+        "prefer-spread": "error",
+        "prefer-template": "off",
+        "quote-props": "off",
+        "quotes": [
+            "error",
+            "double"
+        ],
+        "radix": "error",
+        "require-jsdoc": "off",
+        "rest-spread-spacing": "error",
+        "semi": "error",
+        "semi-spacing": "error",
+        "sort-imports": "error",
+        "sort-vars": "off",
+        "space-before-blocks": "error",
+        "space-before-function-paren": [
+            "error",
+            "never"
+        ],
+        "space-in-parens": [
+            "error",
+            "always"
+        ],
+        "space-infix-ops": "error",
+        "space-unary-ops": "error",
+        "spaced-comment": [
+            "error",
+            "always"
+        ],
+        "strict": "error",
+        "template-curly-spacing": "error",
+        "unicode-bom": [
+            "error",
+            "never"
+        ],
+        "valid-jsdoc": "error",
+        "vars-on-top": "error",
+        "wrap-regex": "error",
+        "yield-star-spacing": "error",
+        "yoda": "error"
+    }
+}

--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,24 @@
+{
+  "js": {
+	"allowed_file_extensions": ["js", "json", "jshintrc", "jscsrc", "jsbeautifyrc"],
+	"eol": "\n",
+	"indent_level": 0,
+	"indent_with_tabs": true,
+	"preserve_newlines": true,
+	"brace_style": "collapse",
+	"break_chained_methods": false,
+	"e4x": false,
+	"end_with_newline": true,
+	"jslint_happy": false,
+	"keep_array_indentation": false,
+	"keep_function_indentation": false,
+	"max_preserve_newlines": 0,
+	"preserve_newlines": true,
+	"space_after_anon_function": false,
+	"space_before_conditional": true,
+	"space_in_empty_paren": false,
+	"space_in_paren": true,
+	"unescape_strings": false,
+	"wrap_line_length": 0
+  }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,7 @@
 module.exports = function( grunt ) {
 
+	"use strict";
+
 	grunt.initConfig( {
 
 		// Import package manifest
@@ -43,6 +45,13 @@ module.exports = function( grunt ) {
 			}
 		},
 
+		eslint: {
+			target: [ "src/**/*.js" ],
+			options: {
+				configFile: ".eslintrc.json"
+			}
+		},
+
 		// Minify definitions
 		uglify: {
 			dist: {
@@ -72,7 +81,7 @@ module.exports = function( grunt ) {
 				browsers: [ "PhantomJS", "Firefox" ]
 			},
 
-			//continuous integration mode: run tests once in PhantomJS browser.
+			// continuous integration mode: run tests once in PhantomJS browser.
 			travis: {
 				configFile: "karma.conf.js",
 				singleRun: true,
@@ -93,13 +102,14 @@ module.exports = function( grunt ) {
 	grunt.loadNpmTasks( "grunt-contrib-concat" );
 	grunt.loadNpmTasks( "grunt-contrib-jshint" );
 	grunt.loadNpmTasks( "grunt-jscs" );
+	grunt.loadNpmTasks( "grunt-eslint" );
 	grunt.loadNpmTasks( "grunt-contrib-uglify" );
 	grunt.loadNpmTasks( "grunt-contrib-coffee" );
 	grunt.loadNpmTasks( "grunt-contrib-watch" );
 	grunt.loadNpmTasks( "grunt-karma" );
 
 	grunt.registerTask( "travis", [ "jshint", "karma:travis" ] );
-	grunt.registerTask( "lint", [ "jshint", "jscs" ] );
+	grunt.registerTask( "lint", [ "jshint", "jscs", "eslint" ] );
 	grunt.registerTask( "build", [ "concat", "uglify" ] );
 	grunt.registerTask( "default", [ "jshint", "build", "karma:unit:run" ] );
 };

--- a/dist/jquery.boilerplate.js
+++ b/dist/jquery.boilerplate.js
@@ -1,5 +1,5 @@
 /*
- *  jquery-boilerplate - v4.0.0
+ *  jquery-boilerplate - v4.1.0
  *  A jump-start for jQuery plugins development.
  *  http://jqueryboilerplate.com
  *
@@ -12,63 +12,63 @@
 
 	"use strict";
 
-		// undefined is used here as the undefined global variable in ECMAScript 3 is
-		// mutable (ie. it can be changed by someone else). undefined isn't really being
-		// passed in so we can ensure the value of it is truly undefined. In ES5, undefined
-		// can no longer be modified.
+	// undefined is used here as the undefined global variable in ECMAScript 3 is
+	// mutable (ie. it can be changed by someone else). undefined isn't really being
+	// passed in so we can ensure the value of it is truly undefined. In ES5, undefined
+	// can no longer be modified.
 
-		// window and document are passed through as local variable rather than global
-		// as this (slightly) quickens the resolution process and can be more efficiently
-		// minified (especially when both are regularly referenced in your plugin).
+	// window and document are passed through as local variables rather than global
+	// as this (slightly) quickens the resolution process and can be more efficiently
+	// minified (especially when both are regularly referenced in your plugin).
 
-		// Create the defaults once
-		var pluginName = "defaultPluginName",
-			defaults = {
-				propertyName: "value"
-			};
+	// Create the defaults once
+	var pluginName = "defaultPluginName",
+		defaults = {
+			propertyName: "value"
+		};
 
-		// The actual plugin constructor
-		function Plugin ( element, options ) {
-			this.element = element;
+	// The actual plugin constructor
+	function Plugin( element, options ) {
+		this.element = element;
 
-			// jQuery has an extend method which merges the contents of two or
-			// more objects, storing the result in the first object. The first object
-			// is generally empty as we don't want to alter the default options for
-			// future instances of the plugin
-			this.settings = $.extend( {}, defaults, options );
-			this._defaults = defaults;
-			this._name = pluginName;
-			this.init();
+		// jQuery has an extend method which merges the contents of two or
+		// more objects, storing the result in the first object. The first object
+		// is generally empty as we don't want to alter the default options for
+		// future instances of the plugin
+		this.settings = $.extend( {}, defaults, options );
+		this._defaults = defaults;
+		this._name = pluginName;
+		this.init();
+	}
+
+	// Avoid Plugin.prototype conflicts
+	$.extend( Plugin.prototype, {
+		init: function() {
+
+			// Place initialization logic here
+			// You already have access to the DOM element and
+			// the options via the instance, e.g. this.element
+			// and this.settings
+			// you can add more functions like the one below and
+			// call them like the example below
+			this.yourOtherFunction( "jQuery Boilerplate" );
+		},
+		yourOtherFunction: function( text ) {
+
+			// some logic
+			$( this.element ).text( text );
 		}
+	} );
 
-		// Avoid Plugin.prototype conflicts
-		$.extend( Plugin.prototype, {
-			init: function() {
-
-				// Place initialization logic here
-				// You already have access to the DOM element and
-				// the options via the instance, e.g. this.element
-				// and this.settings
-				// you can add more functions like the one below and
-				// call them like the example bellow
-				this.yourOtherFunction( "jQuery Boilerplate" );
-			},
-			yourOtherFunction: function( text ) {
-
-				// some logic
-				$( this.element ).text( text );
+	// A really lightweight plugin wrapper around the constructor,
+	// preventing against multiple instantiations
+	$.fn[ pluginName ] = function( options ) {
+		return this.each( function() {
+			if ( !$.data( this, "plugin_" + pluginName ) ) {
+				$.data( this, "plugin_" +
+					pluginName, new Plugin( this, options ) );
 			}
 		} );
-
-		// A really lightweight plugin wrapper around the constructor,
-		// preventing against multiple instantiations
-		$.fn[ pluginName ] = function( options ) {
-			return this.each( function() {
-				if ( !$.data( this, "plugin_" + pluginName ) ) {
-					$.data( this, "plugin_" +
-						pluginName, new Plugin( this, options ) );
-				}
-			} );
-		};
+	};
 
 } )( jQuery, window, document );

--- a/dist/jquery.boilerplate.min.js
+++ b/dist/jquery.boilerplate.min.js
@@ -1,5 +1,5 @@
 /*
- *  jquery-boilerplate - v4.0.0
+ *  jquery-boilerplate - v4.1.0
  *  A jump-start for jQuery plugins development.
  *  http://jqueryboilerplate.com
  *

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,7 @@
 module.exports = function( config ) {
 
+	"use strict";
+
 	config.set( {
 		files: [
 			"node_modules/jquery/dist/jquery.js",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-uglify": "^0.9.2",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-eslint": "^19.0.0",
     "grunt-jscs": "^2.7.0",
     "grunt-karma": "^0.12.0",
     "jscs": "^2.10.1",

--- a/src/jquery.boilerplate.js
+++ b/src/jquery.boilerplate.js
@@ -4,63 +4,63 @@
 
 	"use strict";
 
-		// undefined is used here as the undefined global variable in ECMAScript 3 is
-		// mutable (ie. it can be changed by someone else). undefined isn't really being
-		// passed in so we can ensure the value of it is truly undefined. In ES5, undefined
-		// can no longer be modified.
+	// undefined is used here as the undefined global variable in ECMAScript 3 is
+	// mutable (ie. it can be changed by someone else). undefined isn't really being
+	// passed in so we can ensure the value of it is truly undefined. In ES5, undefined
+	// can no longer be modified.
 
-		// window and document are passed through as local variables rather than global
-		// as this (slightly) quickens the resolution process and can be more efficiently
-		// minified (especially when both are regularly referenced in your plugin).
+	// window and document are passed through as local variables rather than global
+	// as this (slightly) quickens the resolution process and can be more efficiently
+	// minified (especially when both are regularly referenced in your plugin).
 
-		// Create the defaults once
-		var pluginName = "defaultPluginName",
-			defaults = {
-				propertyName: "value"
-			};
+	// Create the defaults once
+	var pluginName = "defaultPluginName",
+		defaults = {
+			propertyName: "value"
+		};
 
-		// The actual plugin constructor
-		function Plugin ( element, options ) {
-			this.element = element;
+	// The actual plugin constructor
+	function Plugin( element, options ) {
+		this.element = element;
 
-			// jQuery has an extend method which merges the contents of two or
-			// more objects, storing the result in the first object. The first object
-			// is generally empty as we don't want to alter the default options for
-			// future instances of the plugin
-			this.settings = $.extend( {}, defaults, options );
-			this._defaults = defaults;
-			this._name = pluginName;
-			this.init();
+		// jQuery has an extend method which merges the contents of two or
+		// more objects, storing the result in the first object. The first object
+		// is generally empty as we don't want to alter the default options for
+		// future instances of the plugin
+		this.settings = $.extend( {}, defaults, options );
+		this._defaults = defaults;
+		this._name = pluginName;
+		this.init();
+	}
+
+	// Avoid Plugin.prototype conflicts
+	$.extend( Plugin.prototype, {
+		init: function() {
+
+			// Place initialization logic here
+			// You already have access to the DOM element and
+			// the options via the instance, e.g. this.element
+			// and this.settings
+			// you can add more functions like the one below and
+			// call them like the example below
+			this.yourOtherFunction( "jQuery Boilerplate" );
+		},
+		yourOtherFunction: function( text ) {
+
+			// some logic
+			$( this.element ).text( text );
 		}
+	} );
 
-		// Avoid Plugin.prototype conflicts
-		$.extend( Plugin.prototype, {
-			init: function() {
-
-				// Place initialization logic here
-				// You already have access to the DOM element and
-				// the options via the instance, e.g. this.element
-				// and this.settings
-				// you can add more functions like the one below and
-				// call them like the example below
-				this.yourOtherFunction( "jQuery Boilerplate" );
-			},
-			yourOtherFunction: function( text ) {
-
-				// some logic
-				$( this.element ).text( text );
+	// A really lightweight plugin wrapper around the constructor,
+	// preventing against multiple instantiations
+	$.fn[ pluginName ] = function( options ) {
+		return this.each( function() {
+			if ( !$.data( this, "plugin_" + pluginName ) ) {
+				$.data( this, "plugin_" +
+					pluginName, new Plugin( this, options ) );
 			}
 		} );
-
-		// A really lightweight plugin wrapper around the constructor,
-		// preventing against multiple instantiations
-		$.fn[ pluginName ] = function( options ) {
-			return this.each( function() {
-				if ( !$.data( this, "plugin_" + pluginName ) ) {
-					$.data( this, "plugin_" +
-						pluginName, new Plugin( this, options ) );
-				}
-			} );
-		};
+	};
 
 } )( jQuery, window, document );

--- a/test/spec/jquery.boilerplate.spec.js
+++ b/test/spec/jquery.boilerplate.spec.js
@@ -42,11 +42,13 @@
 	} );
 
 	QUnit.test( "enable custom config", function( assert ) {
-		var pluginData = $fixture.data( "plugin_defaultPluginName" );
+		var pluginData = {};
 
 		$fixture.defaultPluginName( {
 			foo: "bar"
 		} );
+
+		pluginData = $fixture.data( "plugin_defaultPluginName" );
 
 		assert.deepEqual(
 			pluginData.settings, {
@@ -67,10 +69,12 @@
 	QUnit.test(
 		"has #yourOtherFunction working as expected",
 		function( assert ) {
-			var instance = $fixture.data( "plugin_defaultPluginName" ),
+			var instance = {},
 				expectedText = "foobar";
 
 			$fixture.defaultPluginName();
+
+			instance = $fixture.data( "plugin_defaultPluginName" );
 
 			instance.yourOtherFunction( expectedText );
 			assert.equal( $fixture.text(), expectedText );

--- a/test/spec/jquery.boilerplate.spec.js
+++ b/test/spec/jquery.boilerplate.spec.js
@@ -2,8 +2,8 @@
 
 	"use strict";
 
-	var $testCanvas = $( "#testCanvas" );
-	var $fixture = null;
+	var $testCanvas = $( "#testCanvas" ),
+		$fixture = null;
 
 	QUnit.module( "jQuery Boilerplate", {
 		beforeEach: function() {
@@ -42,15 +42,14 @@
 	} );
 
 	QUnit.test( "enable custom config", function( assert ) {
+		var pluginData = $fixture.data( "plugin_defaultPluginName" );
+
 		$fixture.defaultPluginName( {
 			foo: "bar"
 		} );
 
-		var pluginData = $fixture.data( "plugin_defaultPluginName" );
-
 		assert.deepEqual(
-			pluginData.settings,
-			{
+			pluginData.settings, {
 				propertyName: "value",
 				foo: "bar"
 			},
@@ -68,10 +67,10 @@
 	QUnit.test(
 		"has #yourOtherFunction working as expected",
 		function( assert ) {
-			$fixture.defaultPluginName();
-
 			var instance = $fixture.data( "plugin_defaultPluginName" ),
 				expectedText = "foobar";
+
+			$fixture.defaultPluginName();
 
 			instance.yourOtherFunction( expectedText );
 			assert.equal( $fixture.text(), expectedText );


### PR DESCRIPTION
## Beautify

Use settings from `.jsbeautifyrc` for format javascript.

Tested with:
- [Brackets beautify](https://github.com/brackets-beautify/brackets-beautify)
- [Atom beautify](https://github.com/Glavin001/atom-beautify)
- [Sublime HTMLPrettify](https://github.com/victorporof/Sublime-HTMLPrettify)
## ESLint

JSCS has [merged](https://medium.com/@markelog/jscs-end-of-the-line-bc9bf0b3fdb2) with ESLint, that is why we need ESLint.

> JSCS 3.0 ... will be the last version of JSCS.
